### PR TITLE
Define admin-ajax.php URL in PHP and pass to front end

### DIFF
--- a/discogs-block.php
+++ b/discogs-block.php
@@ -30,6 +30,8 @@ add_action( 'init', 'drdb_discogs_block_register_scripts' );
 
     function drdb_render_releases() {
         wp_enqueue_script( 'jquery' );
+        wp_localize_script( 'drdb_script', 'discogs_fetch',
+        array( 'ajaxurl' => admin_url( 'admin-ajax.php' ) ) );
         wp_enqueue_script( 'drdb_script' );
         return '
         <div id="drdb-discogs-block-parent" class="drdb-discogs-block-parent">

--- a/drdb-discogs-block.js
+++ b/drdb-discogs-block.js
@@ -17,7 +17,7 @@ const getReleases = (page, limit) => {
 
 	jQuery.ajax({
 		async: false,
-		url: '/wp-admin/admin-ajax.php',
+		url: discogs_fetch.ajaxurl,
 		type: 'get',
 		data: {
 			action: 'drdb_discogs_fetch',


### PR DESCRIPTION
Currently the ajax-admin.php is called explicitly using the URL `/wp-admin/admin-ajax.php`. This can be problematic because if wp-admin is in a different location, then this file may not be accessible. Defining the path in PHP using `admin_url`, then passing the path to the front end using `wp_localize_script` will safeguard against failed calls.