### PR TITLE
Add periods, hyphens, and underscores to the username regex

### DIFF
--- a/blocks-for-discogs.php
+++ b/blocks-for-discogs.php
@@ -307,7 +307,7 @@ function drbfd_load_menu() {
     function drbfd_blocks_for_discogs_validate_username( $input ) {
 		
         $input['username'] = preg_replace(
-            '/[^A-Za-z0-9]/',
+            '/[^A-Za-z0-9._-]/',
             '',
             $input['username'] );
 			return $input;


### PR DESCRIPTION
This PR will solve the issue: Username #5, by adding hyphens, periods, and underscores to the username's sanitization RegEx.

Currently, when you type a username into the Discogs Settings Block field, it strips the hyphen, period, and underscore, which are allowed characters in discogs.com's usernames. 

### Testing instructions: 

1. In /wp-admin, click Blocks for Discogs in the menu to open the settings.
2. Type any username into the "Your Discogs Username" field (e.g. a-z, 1-07, !@#$%^&, hyphens, underscores, and periods)
3. Click Save Changes

### Results:  
Only a-z, 1-0, hyphens, underscores, and periods are left in the username field and saved to the database wp_options table.  

## Examples: 

Before sanitization:
<img width="976" alt="image" src="https://user-images.githubusercontent.com/29527450/207150287-83e64b38-bf05-4cd1-9a5b-c799d9eb4ded.png">

After sanitization: 
<img width="1055" alt="image" src="https://user-images.githubusercontent.com/29527450/207150452-9fc4d6e0-602f-442e-a325-88d21b8d9b83.png">
